### PR TITLE
Update Rundeck to 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV MYHOST MYHOST
 ENV MAILFROM MAILFROM
 
 # Download Rundeck
-ADD http://download.rundeck.org/deb/rundeck-2.3.2-1-GA.deb /tmp/rundeck.deb
+ADD http://download.rundeck.org/deb/rundeck-2.5.1-1-GA.deb /tmp/rundeck.deb
 
 # Run the installation script
 RUN /install.sh


### PR DESCRIPTION
This Dockerfile is awesome, but I needed some new functionality introduced after 2.3.2, so I bumped the version to 2.5.1 and I've been using this under a very moderate workload and it seems to be working pretty well.