### PR TITLE
LDAP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ If you want to build it yourself:
 ```
 make build
 ```
+
+
+## Configuration
+
+* Use LDAP for authentication: `-v /path/to/jaas-ldap.conf:/etc/rundeck/jaas-ldap.conf -e LDAP_CONFIG_PATH=/etc/rundeck/jaas-ldap.conf`
+* Supply a custom `admin.aclpolicy`: `-v /path/to/policy/on/host.aclpolicy:/etc/rundeck/admin.aclpolicy`

--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,9 @@ sed -i 's/&>>\/var\/log\/rundeck\/service.log &$//g' /etc/init.d/rundeckd
 sed -i "s/^admin:admin/admin:$RDPASS/g" /etc/rundeck/realm.properties
 sed -i "s/localhost:4440/$MYHOST:4440/g" /etc/rundeck/rundeck-config.properties
 
+sed -i "s,/etc/rundeck/jaas-loginmodule.conf,AUTH_LOGIN_CONFIG,g" /etc/rundeck/profile
+sed -i "s/RDpropertyfilelogin/LOGINMODULE_NAME/g" /etc/rundeck/profile
+
 # Generate a new passwordless SSH key
 #mkdir -p /var/lib/rundeck/.ssh/
 #chown rundeck:rundeck /var/lib/rundeck/.ssh

--- a/run.sh
+++ b/run.sh
@@ -14,5 +14,12 @@ sed -i "s/RDPASS/$RDPASS/g" /etc/rundeck/realm.properties
 # Change the Rundeck admin password
 echo "grails.mail.default.from=$MAILFROM" >> /etc/rundeck/rundeck-config.properties
 
-#echo -e "$RDPASS\n$RDPASS" | passwd
+if [ -n "${LDAP_CONFIG_PATH+1}" ]; then
+  sed -i "s,AUTH_LOGIN_CONFIG,$LDAP_CONFIG_PATH,g" /etc/rundeck/profile
+  sed -i "s/LOGINMODULE_NAME/ldap/g" /etc/rundeck/profile
+else
+  sed -i "s,AUTH_LOGIN_CONFIG,/etc/rundeck/jaas-loginmodule.conf,g" /etc/rundeck/profile
+  sed -i "s/LOGINMODULE_NAME/RDpropertyfilelogin/g" /etc/rundeck/profile
+fi
+
 /etc/init.d/rundeckd start


### PR DESCRIPTION
Rundeck already has great support for LDAP, but this lets you pass the appropriate configuration to get the container started with LDAP support.  By supplying the `LDAP_CONFIG_PATH` environment variable and mounting the config file into the container, `run.sh` will switch around configs to make things work properly with the LDAP loginmodule.

Here's an example of starting up the container with LDAP and a custom `admin.aclpolicy`:

```
docker run -d \
           -p 4440:4440 \
           -p 4443:4443 \
           -e MYHOST=192.168.59.103 \
           -e RDPASS=password \
           -e MAILFROM=bmorton@yammer-inc.com \
           -e LDAP_CONFIG_PATH=/etc/rundeck/jaas-ldap.conf \
           -v /Users/bmorton/Code/docker-rundeck/examples/jaas-ldap.conf:/etc/rundeck/jaas-ldap.conf \
           -v /Users/bmorton/Code/docker-rundeck/examples/admin.aclpolicy:/etc/rundeck/admin.aclpolicy \
           --name=rundeck \
           bmorton/rundeck
```

Note that I didn't include the example configs, you'd have to get them from rundeck.org.  If you think those would be good to include, I can include them here (or link to them in the README).